### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 var httpntlm = require("httpntlm");
 var cookie = require("cookie");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var Auth = function (settings) {
 

--- a/lib/ws-security/model/WSSecurityIssuedTokenWithSymmetricProofKey.js
+++ b/lib/ws-security/model/WSSecurityIssuedTokenWithSymmetricProofKey.js
@@ -1,7 +1,7 @@
 var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var template = fs.readFileSync(path.join(__dirname, '/templates/WSSecurityIssuedTokenWithSymmetricProofKey.xml'), 'utf-8');
 

--- a/lib/ws-security/model/WSSecurityUsernameToken.js
+++ b/lib/ws-security/model/WSSecurityUsernameToken.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var template = fs.readFileSync(path.join(__dirname, '/templates/WSSecurityUsernameToken.xml'), 'utf-8');
 
 function WSSecurityUsernameToken(opts) {

--- a/lib/ws-security/model/soapMessage.js
+++ b/lib/ws-security/model/soapMessage.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var template = fs.readFileSync(path.join(__dirname, '/templates/soapMessage.xml'), 'utf-8');
 

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "cookie": "^0.3.1",
     "httpntlm": "^1.6.1",
     "mem-cache": "^0.0.5",
-    "node-uuid": "^1.4.7",
     "path": "^0.12.7",
     "request": "^2.74.0",
     "traverse": "^0.6.6",
+    "uuid": "^3.0.0",
     "xml2js": "^0.4.17",
     "xmldom": "^0.1.22",
     "xpath": "^0.0.23"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.